### PR TITLE
Mais opções de configuração

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Vagrantfile
 *.sublime-project
 *.sublime-workspace
 .phpintel/
+vendor/autoload.php

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ Vagrantfile
 *.sublime-project
 *.sublime-workspace
 .phpintel/
-vendor/autoload.php

--- a/MdWsSeiRest.php
+++ b/MdWsSeiRest.php
@@ -285,12 +285,6 @@ class MdWsSeiRest extends SeiIntegracao
 
     public function adicionarElementoMenu()
     {
-
-        $desabilitarQrCodeAplicativo = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'DesabilitarQrCodeAplicativo', false, false);
-        if($desabilitarQrCodeAplicativo){
-            return '';
-        }
-
         try{
             $nomeArquivo = 'QRCODE_'
                 . self::NOME_MODULO

--- a/MdWsSeiRest.php
+++ b/MdWsSeiRest.php
@@ -285,6 +285,13 @@ class MdWsSeiRest extends SeiIntegracao
 
     public function adicionarElementoMenu()
     {
+
+        $desabilitarQrCodeAplicativo = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'DesabilitarQrCodeAplicativo', false, false);
+
+        if($desabilitarQrCodeAplicativo){
+            return '';
+        }
+
         try{
             $nomeArquivo = 'QRCODE_'
                 . self::NOME_MODULO

--- a/MdWsSeiRest.php
+++ b/MdWsSeiRest.php
@@ -285,6 +285,12 @@ class MdWsSeiRest extends SeiIntegracao
 
     public function adicionarElementoMenu()
     {
+
+        $desabilitarQrCodeAplicativo = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'DesabilitarQrCodeAplicativo', false, false);
+        if($desabilitarQrCodeAplicativo){
+            return '';
+        }
+
         try{
             $nomeArquivo = 'QRCODE_'
                 . self::NOME_MODULO

--- a/docs/instalacao.md
+++ b/docs/instalacao.md
@@ -48,10 +48,13 @@
                'IdApp' => '{ID do app registrado no serviço de notificação}',
                'ChaveAutorizacao' => '{Chave de autorização do serviço de notificação}',
                'TokenSecret' => '{chave unica com pelo menos 32 chars. Pode usar o comando uuidgen para gerar}',
-               'DesabilitarQrCodeAplicativo' => '{(boolean) se true desabilita a visão do QrCode do aplicativo no menu do SEI. Padrão=false.}',
-               'DesabilitarServicoNotificacao' => '{(boolean) se true desabilita o serviço de autenticação. Padrão=false}',
-               'ServicosHabilitados' => '{(array|boolean) lista de expressões regulares para habilitar apenas os serviços que combinem com os padrões listados. Padrão=false. Exemplo "ServicosHabilitados" => ["hipoteseLegal.*"]}',
-               'ServicosDesabilitados' => '{(array|boolean) lista de expressões regulares para desabilitar apenas os serviços que combinem com os padrões listados. Padrão=false. Exemplo "ServicosDesabilitados" => ["bloco/assinatura.*","versao"]}',
+
+               //chaves opcionais
+               'DesabilitarQrCodeAplicativo' => '{(bool) se true desabilita a visão do QrCode do aplicativo no menu do SEI. Padrão=false.}',
+               'DesabilitarServicoNotificacao' => '{(bool) se true desabilita o serviço de autenticação. Padrão=false}',
+               'ServicosHabilitados' => '{(array|bool) lista de expressões regulares para habilitar apenas os serviços que combinem com os padrões listados. Padrão=false. Exemplo "ServicosHabilitados" => ["hipoteseLegal.*"]}',
+               'ServicosDesabilitados' => '{(array|bool) lista de expressões regulares para desabilitar apenas os serviços que combinem com os padrões listados. Padrão=false. Exemplo "ServicosDesabilitados" => ["bloco/assinatura.*","versao"]}',
+               'Sleep' => '{int} valor padrão para sleeps nas chamadas ',
            ),
 
            (...)

--- a/docs/instalacao.md
+++ b/docs/instalacao.md
@@ -47,7 +47,11 @@
                'UrlServicoNotificacao' => '{URL do serviço de notificação}',
                'IdApp' => '{ID do app registrado no serviço de notificação}',
                'ChaveAutorizacao' => '{Chave de autorização do serviço de notificação}',
-               'TokenSecret' => '{chave unica com pelo menos 32 chars. Pode usar o comando uuidgen para gerar}'
+               'TokenSecret' => '{chave unica com pelo menos 32 chars. Pode usar o comando uuidgen para gerar}',
+               'DesabilitarQrCodeAplicativo' => '{(boolean) se true desabilita a visão do QrCode do aplicativo no menu do SEI. Padrão=false.}',
+               'DesabilitarServicoNotificacao' => '{(boolean) se true desabilita o serviço de autenticação. Padrão=false}',
+               'ServicosHabilitados' => '{(array|boolean) lista de expressões regulares para habilitar apenas os serviços que combinem com os padrões listados. Padrão=false. Exemplo "ServicosHabilitados" => ["hipoteseLegal.*"]}',
+               'ServicosDesabilitados' => '{(array|boolean) lista de expressões regulares para desabilitar apenas os serviços que combinem com os padrões listados. Padrão=false. Exemplo "ServicosDesabilitados" => ["bloco/assinatura.*","versao"]}',
            ),
 
            (...)

--- a/rn/MdWsSeiAgendamentoRN.php
+++ b/rn/MdWsSeiAgendamentoRN.php
@@ -21,6 +21,16 @@ class MdWsSeiAgendamentoRN extends InfraRN
             InfraDebug::getInstance()->setBolEcho(false);
             InfraDebug::getInstance()->limpar();
 
+            $desabilitarServicoNotificacao = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'DesabilitarServicoNotificacao', false, false);
+            if($desabilitarServicoNotificacao){
+                InfraDebug::getInstance()->gravar("NOTIFICAÇÃO NÃO SERÁ REALIZADA POIS DE ATIVIDADES 'DesabilitarServicoNotificacao = false'");
+                InfraDebug::getInstance()->gravar('FIM');
+                InfraDebug::getInstance()->setBolLigado(false);
+                InfraDebug::getInstance()->setBolDebugInfra(false);
+                InfraDebug::getInstance()->setBolEcho(false);
+                return;
+            }
+
             $numSeg = InfraUtil::verificarTempoProcessamento();
             $arrErroNotificacao = [];
             $contSucessos = 0;

--- a/rn/MdWsSeiAgendamentoRN.php
+++ b/rn/MdWsSeiAgendamentoRN.php
@@ -13,6 +13,14 @@ class MdWsSeiAgendamentoRN extends InfraRN
 
     protected function notificacaoAtividadesControlado()
     {
+
+        $desabilitarServicoNotificacao = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'DesabilitarServicoNotificacao', false, false);
+
+        if($desabilitarServicoNotificacao){
+            LogSEI::getInstance()->gravar('Notificações não realizadas pois "DesabilitarServicoNotificacao = true". ', InfraLog::$INFORMACAO);
+            return;
+        }
+
         try {
             ini_set('max_execution_time', '0');
             ini_set('memory_limit', '1024M');

--- a/rn/MdWsSeiAgendamentoRN.php
+++ b/rn/MdWsSeiAgendamentoRN.php
@@ -21,16 +21,6 @@ class MdWsSeiAgendamentoRN extends InfraRN
             InfraDebug::getInstance()->setBolEcho(false);
             InfraDebug::getInstance()->limpar();
 
-            $desabilitarServicoNotificacao = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'DesabilitarServicoNotificacao', false, false);
-            if($desabilitarServicoNotificacao){
-                InfraDebug::getInstance()->gravar("NOTIFICAÇÃO NÃO SERÁ REALIZADA POIS DE ATIVIDADES 'DesabilitarServicoNotificacao = false'");
-                InfraDebug::getInstance()->gravar('FIM');
-                InfraDebug::getInstance()->setBolLigado(false);
-                InfraDebug::getInstance()->setBolDebugInfra(false);
-                InfraDebug::getInstance()->setBolEcho(false);
-                return;
-            }
-
             $numSeg = InfraUtil::verificarTempoProcessamento();
             $arrErroNotificacao = [];
             $contSucessos = 0;

--- a/rn/MdWsSeiBlocoRN.php
+++ b/rn/MdWsSeiBlocoRN.php
@@ -39,7 +39,7 @@ class MdWsSeiBlocoRN extends InfraRN {
     public function apiAssinarBloco($idBloco, $idOrgao, $strCargoFuncao, $siglaUsuario, $senhaUsuario, $idUsuario)
     {
         try{
-            sleep(3);
+            sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 3));
             $objRelBlocoProtocoloDTO = new RelBlocoProtocoloDTO();
             $objRelBlocoProtocoloDTO->setNumIdBloco($idBloco);
             $objRelBlocoProtocoloDTO->setOrdNumSequencia(InfraDTO::$TIPO_ORDENACAO_ASC);
@@ -80,7 +80,7 @@ class MdWsSeiBlocoRN extends InfraRN {
     public function apiAssinarDocumentos($idOrgao, $strCargoFuncao, $siglaUsuario, $senhaUsuario, $idUsuario, $arrIdDocumentos)
     {
         try{
-            sleep(3);
+            sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 3));
             if(!$arrIdDocumentos){
                 return MdWsSeiRest::formataRetornoSucessoREST('Nenhum documento foi informado para ser assinado.');
             }

--- a/rn/MdWsSeiBloco_V1_RN.php
+++ b/rn/MdWsSeiBloco_V1_RN.php
@@ -39,7 +39,7 @@ class MdWsSeiBloco_V1_RN extends InfraRN {
     public function apiAssinarBloco($idBloco, $idOrgao, $strCargoFuncao, $siglaUsuario, $senhaUsuario, $idUsuario)
     {
         try{
-            sleep(3);
+            sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 3));
             $objRelBlocoProtocoloDTO = new RelBlocoProtocoloDTO();
             $objRelBlocoProtocoloDTO->setNumIdBloco($idBloco);
             $objRelBlocoProtocoloDTO->setOrdNumSequencia(InfraDTO::$TIPO_ORDENACAO_ASC);

--- a/rn/MdWsSeiDocumentoRN.php
+++ b/rn/MdWsSeiDocumentoRN.php
@@ -844,7 +844,7 @@ class MdWsSeiDocumentoRN extends DocumentoRN
     public function assinarDocumentoControlado(AssinaturaDTO $assinaturaDTO)
     {
         try {
-            sleep(3);
+            sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 3));
             $assinaturaDTO->setStrStaFormaAutenticacao(AssinaturaRN::$TA_SENHA);
             // $assinaturaDTO->setNumIdContextoUsuario(null);
             $documentoRN = new DocumentoRN();

--- a/rn/MdWsSeiDocumento_V1_RN.php
+++ b/rn/MdWsSeiDocumento_V1_RN.php
@@ -1236,7 +1236,7 @@ class MdWsSeiDocumento_V1_RN extends DocumentoRN {
      */
     public function assinarDocumentoControlado(AssinaturaDTO $assinaturaDTO) {
         try {
-            sleep(3);
+            sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 3));
             $assinaturaDTO->setStrStaFormaAutenticacao(AssinaturaRN::$TA_SENHA);
             // $assinaturaDTO->setNumIdContextoUsuario(null);
             $documentoRN = new DocumentoRN();

--- a/rn/MdWsSeiUsuarioRN.php
+++ b/rn/MdWsSeiUsuarioRN.php
@@ -191,7 +191,7 @@ class MdWsSeiUsuarioRN extends InfraRN {
             ); 
 
             if(!$ret){
-                sleep(3);
+                sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 3));
                 throw new InfraException('Usuário ou senha inválido!');
             }
             

--- a/scripts/sei_atualizar_versao_modulo_wssei.php
+++ b/scripts/sei_atualizar_versao_modulo_wssei.php
@@ -85,7 +85,13 @@ require_once dirname(__FILE__) . '/../web/SEI.php';
                     $infraAgemdanemtoTarefaDTO->setStrPeriodicidadeComplemento('0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23');
                 }
         
-                $infraAgemdanemtoTarefaDTO->setStrSinAtivo('S');
+                $desabilitarServicoNotificacao = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'DesabilitarServicoNotificacao', false, false);
+                if($desabilitarServicoNotificacao){
+                    $infraAgemdanemtoTarefaDTO->setStrSinAtivo('N');
+                }else{
+                    $infraAgemdanemtoTarefaDTO->setStrSinAtivo('S');
+                }
+                
                 $infraAgemdanemtoTarefaDTO->setStrSinSucesso('S');
         
                 $infraAgemdanemtoTarefaBD = new InfraAgendamentoTarefaBD(BancoSEI::getInstance());
@@ -116,9 +122,10 @@ require_once dirname(__FILE__) . '/../web/SEI.php';
             public function versao_1_0_4($strVersaoAtual)
             {
                 $this->logar("VERIFICANDO SE A CHAVE: TokenSecret ESTA PRESENTE NO ARQUIVO DE CONFIGURACOES.");
+                $desabilitarServicoNotificacao = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'DesabilitarServicoNotificacao', false, false);
                 
                 $token = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'TokenSecret', false);
-                if((!$token) || (strlen($token)<25)){
+                if(!$desabilitarServicoNotificacao && ((!$token) || (strlen($token)<25))){
                     $msg = 'Token Secret inexistente ou tamanho menor que o permitido! Verifique o manual de instalacao do módulo. ';
                     $msg = $msg . 'O script de instalacao foi interrompido. Módulo nao instalado corretamente. ';
                     $msg = $msg . 'Ajuste a chave e rode novamente o script.';

--- a/scripts/sei_atualizar_versao_modulo_wssei.php
+++ b/scripts/sei_atualizar_versao_modulo_wssei.php
@@ -50,56 +50,46 @@ require_once dirname(__FILE__) . '/../web/SEI.php';
         
             public function versao_0_8_12($strVersaoAtual)
             {
-                $desabilitarServicoNotificacao = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'DesabilitarServicoNotificacao', false, false);
-
-                if($desabilitarServicoNotificacao){
-
-                    $this->logar("Serviço de notificação não será instalado pois 'DesabilitarServicoNotificacao = false'.");
-                    
-                }else{
-
-                    $this->logar("CRIANDO TABELA PARA NOTIFICACAO DE ATIVIDADES.");
-                    $objInfraMetaBD = new InfraMetaBD(BancoSEI::getInstance());
-                    BancoSEI::getInstance()->executarSql(
-                        'CREATE TABLE md_wssei_notificacao_ativ (
-                            id_notificacao_atividade ' . $objInfraMetaBD->tipoNumero() . '  NOT NULL ,
-                            id_atividade ' . $objInfraMetaBD->tipoNumero() . '  NOT NULL ,
-                            titulo ' . $objInfraMetaBD->tipoTextoFixo(150) . '  NOT NULL ,
-                            mensagem ' . $objInfraMetaBD->tipoTextoGrande() . '  NOT NULL ,
-                            dth_notificacao ' . $objInfraMetaBD->tipoDataHora() . '  NOT NULL)'
-                    );
-                    BancoSEI::getInstance()->criarSequencialNativa('seq_md_wssei_notificacao_ativ',1);
-                    $objInfraMetaBD->criarIndice('md_wssei_notificacao_ativ','i01_md_wssei_notificacao_ativ',array('id_notificacao_atividade'));
-                    $objInfraMetaBD->criarIndice('md_wssei_notificacao_ativ','i02_md_wssei_notificacao_ativ',array('id_atividade'));
-                    $objInfraMetaBD->criarIndice('md_wssei_notificacao_ativ','i03_md_wssei_notificacao_ativ',array('id_notificacao_atividade','id_atividade'));
-                    BancoSEI::getInstance()->executarSql('alter table md_wssei_notificacao_ativ add constraint fk_md_wssei_not_ativ_id_ativ foreign key (id_atividade) references atividade (id_atividade) on delete cascade');
-            
-                    $infraAgemdanemtoTarefaDTO = new InfraAgendamentoTarefaDTO();
-                    $infraAgemdanemtoTarefaDTO->setStrDescricao('Agendamento para notificacao de atividades.');
-                    $infraAgemdanemtoTarefaDTO->setStrComando('MdWsSeiAgendamentoRN::notificacaoAtividades');
-            
-                    //Obtem valor do SEI.php
-                    $numVersaoAtualSEI = explode('.', SEI_VERSAO);
-                    $numVersaoAtualSEI = array_map(function($item){ return str_pad($item, 2, '0', STR_PAD_LEFT); }, $numVersaoAtualSEI);
-                    $numVersaoAtualSEI = intval(join($numVersaoAtualSEI));
-                    $numVersaoMudancaAgendamento = explode('.', '3.1.0');
-                    $numVersaoMudancaAgendamento = array_map(function($item){ return str_pad($item, 2, '0', STR_PAD_LEFT); }, $numVersaoMudancaAgendamento);
-                    $numVersaoMudancaAgendamento = intval(join($numVersaoMudancaAgendamento));
-                    if($numVersaoMudancaAgendamento >= $numVersaoAtualSEI){
-                        $infraAgemdanemtoTarefaDTO->setStrStaPeriodicidadeExecucao('N');
-                        $infraAgemdanemtoTarefaDTO->setStrPeriodicidadeComplemento('0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55');
-                    } else {
-                        $infraAgemdanemtoTarefaDTO->setStrStaPeriodicidadeExecucao('D');
-                        $infraAgemdanemtoTarefaDTO->setStrPeriodicidadeComplemento('0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23');
-                    }
-            
-                    $infraAgemdanemtoTarefaDTO->setStrSinAtivo('S');
-                    $infraAgemdanemtoTarefaDTO->setStrSinSucesso('S');
-            
-                    $infraAgemdanemtoTarefaBD = new InfraAgendamentoTarefaBD(BancoSEI::getInstance());
-                    $infraAgemdanemtoTarefaBD->cadastrar($infraAgemdanemtoTarefaDTO);
+                $this->logar("CRIANDO TABELA PARA NOTIFICACAO DE ATIVIDADES.");
+                $objInfraMetaBD = new InfraMetaBD(BancoSEI::getInstance());
+                BancoSEI::getInstance()->executarSql(
+                    'CREATE TABLE md_wssei_notificacao_ativ (
+                        id_notificacao_atividade ' . $objInfraMetaBD->tipoNumero() . '  NOT NULL ,
+                        id_atividade ' . $objInfraMetaBD->tipoNumero() . '  NOT NULL ,
+                        titulo ' . $objInfraMetaBD->tipoTextoFixo(150) . '  NOT NULL ,
+                        mensagem ' . $objInfraMetaBD->tipoTextoGrande() . '  NOT NULL ,
+                        dth_notificacao ' . $objInfraMetaBD->tipoDataHora() . '  NOT NULL)'
+                );
+                BancoSEI::getInstance()->criarSequencialNativa('seq_md_wssei_notificacao_ativ',1);
+                $objInfraMetaBD->criarIndice('md_wssei_notificacao_ativ','i01_md_wssei_notificacao_ativ',array('id_notificacao_atividade'));
+                $objInfraMetaBD->criarIndice('md_wssei_notificacao_ativ','i02_md_wssei_notificacao_ativ',array('id_atividade'));
+                $objInfraMetaBD->criarIndice('md_wssei_notificacao_ativ','i03_md_wssei_notificacao_ativ',array('id_notificacao_atividade','id_atividade'));
+                BancoSEI::getInstance()->executarSql('alter table md_wssei_notificacao_ativ add constraint fk_md_wssei_not_ativ_id_ativ foreign key (id_atividade) references atividade (id_atividade) on delete cascade');
+        
+                $infraAgemdanemtoTarefaDTO = new InfraAgendamentoTarefaDTO();
+                $infraAgemdanemtoTarefaDTO->setStrDescricao('Agendamento para notificacao de atividades.');
+                $infraAgemdanemtoTarefaDTO->setStrComando('MdWsSeiAgendamentoRN::notificacaoAtividades');
+        
+                //Obtem valor do SEI.php
+                $numVersaoAtualSEI = explode('.', SEI_VERSAO);
+                $numVersaoAtualSEI = array_map(function($item){ return str_pad($item, 2, '0', STR_PAD_LEFT); }, $numVersaoAtualSEI);
+                $numVersaoAtualSEI = intval(join($numVersaoAtualSEI));
+                $numVersaoMudancaAgendamento = explode('.', '3.1.0');
+                $numVersaoMudancaAgendamento = array_map(function($item){ return str_pad($item, 2, '0', STR_PAD_LEFT); }, $numVersaoMudancaAgendamento);
+                $numVersaoMudancaAgendamento = intval(join($numVersaoMudancaAgendamento));
+                if($numVersaoMudancaAgendamento >= $numVersaoAtualSEI){
+                    $infraAgemdanemtoTarefaDTO->setStrStaPeriodicidadeExecucao('N');
+                    $infraAgemdanemtoTarefaDTO->setStrPeriodicidadeComplemento('0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55');
+                } else {
+                    $infraAgemdanemtoTarefaDTO->setStrStaPeriodicidadeExecucao('D');
+                    $infraAgemdanemtoTarefaDTO->setStrPeriodicidadeComplemento('0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23');
                 }
-                
+        
+                $infraAgemdanemtoTarefaDTO->setStrSinAtivo('S');
+                $infraAgemdanemtoTarefaDTO->setStrSinSucesso('S');
+        
+                $infraAgemdanemtoTarefaBD = new InfraAgendamentoTarefaBD(BancoSEI::getInstance());
+                $infraAgemdanemtoTarefaBD->cadastrar($infraAgemdanemtoTarefaDTO);
                 $this->logar("VERSÃO 0.8.12 atualizada.");
             }
         
@@ -125,24 +115,16 @@ require_once dirname(__FILE__) . '/../web/SEI.php';
         
             public function versao_1_0_4($strVersaoAtual)
             {
-
-                $desabilitarServicoNotificacao = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'DesabilitarServicoNotificacao', false, false);
-
-                if($desabilitarServicoNotificacao){
-                    $this->logar("Serviço de notificação não será instalado pois 'DesabilitarServicoNotificacao = false'.");
-                }else{
-                    $this->logar("VERIFICANDO SE A CHAVE: TokenSecret ESTA PRESENTE NO ARQUIVO DE CONFIGURACOES.");
+                $this->logar("VERIFICANDO SE A CHAVE: TokenSecret ESTA PRESENTE NO ARQUIVO DE CONFIGURACOES.");
                 
-                    $token = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'TokenSecret', false);
-                    if((!$token) || (strlen($token)<25)){
-                        $msg = 'Token Secret inexistente ou tamanho menor que o permitido! Verifique o manual de instalacao do módulo. ';
-                        $msg = $msg . 'O script de instalacao foi interrompido. Módulo nao instalado corretamente. ';
-                        $msg = $msg . 'Ajuste a chave e rode novamente o script.';
-                        $this->logar($msg);
-                        throw new InfraException($msg);
-                    }
+                $token = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'TokenSecret', false);
+                if((!$token) || (strlen($token)<25)){
+                    $msg = 'Token Secret inexistente ou tamanho menor que o permitido! Verifique o manual de instalacao do módulo. ';
+                    $msg = $msg . 'O script de instalacao foi interrompido. Módulo nao instalado corretamente. ';
+                    $msg = $msg . 'Ajuste a chave e rode novamente o script.';
+                    $this->logar($msg);
+                    throw new InfraException($msg);
                 }
-                
         
                 $this->logar("VERSÃO 1.0.4 atualizada.");
             }

--- a/scripts/sei_atualizar_versao_modulo_wssei.php
+++ b/scripts/sei_atualizar_versao_modulo_wssei.php
@@ -50,46 +50,56 @@ require_once dirname(__FILE__) . '/../web/SEI.php';
         
             public function versao_0_8_12($strVersaoAtual)
             {
-                $this->logar("CRIANDO TABELA PARA NOTIFICACAO DE ATIVIDADES.");
-                $objInfraMetaBD = new InfraMetaBD(BancoSEI::getInstance());
-                BancoSEI::getInstance()->executarSql(
-                    'CREATE TABLE md_wssei_notificacao_ativ (
-                        id_notificacao_atividade ' . $objInfraMetaBD->tipoNumero() . '  NOT NULL ,
-                        id_atividade ' . $objInfraMetaBD->tipoNumero() . '  NOT NULL ,
-                        titulo ' . $objInfraMetaBD->tipoTextoFixo(150) . '  NOT NULL ,
-                        mensagem ' . $objInfraMetaBD->tipoTextoGrande() . '  NOT NULL ,
-                        dth_notificacao ' . $objInfraMetaBD->tipoDataHora() . '  NOT NULL)'
-                );
-                BancoSEI::getInstance()->criarSequencialNativa('seq_md_wssei_notificacao_ativ',1);
-                $objInfraMetaBD->criarIndice('md_wssei_notificacao_ativ','i01_md_wssei_notificacao_ativ',array('id_notificacao_atividade'));
-                $objInfraMetaBD->criarIndice('md_wssei_notificacao_ativ','i02_md_wssei_notificacao_ativ',array('id_atividade'));
-                $objInfraMetaBD->criarIndice('md_wssei_notificacao_ativ','i03_md_wssei_notificacao_ativ',array('id_notificacao_atividade','id_atividade'));
-                BancoSEI::getInstance()->executarSql('alter table md_wssei_notificacao_ativ add constraint fk_md_wssei_not_ativ_id_ativ foreign key (id_atividade) references atividade (id_atividade) on delete cascade');
-        
-                $infraAgemdanemtoTarefaDTO = new InfraAgendamentoTarefaDTO();
-                $infraAgemdanemtoTarefaDTO->setStrDescricao('Agendamento para notificacao de atividades.');
-                $infraAgemdanemtoTarefaDTO->setStrComando('MdWsSeiAgendamentoRN::notificacaoAtividades');
-        
-                //Obtem valor do SEI.php
-                $numVersaoAtualSEI = explode('.', SEI_VERSAO);
-                $numVersaoAtualSEI = array_map(function($item){ return str_pad($item, 2, '0', STR_PAD_LEFT); }, $numVersaoAtualSEI);
-                $numVersaoAtualSEI = intval(join($numVersaoAtualSEI));
-                $numVersaoMudancaAgendamento = explode('.', '3.1.0');
-                $numVersaoMudancaAgendamento = array_map(function($item){ return str_pad($item, 2, '0', STR_PAD_LEFT); }, $numVersaoMudancaAgendamento);
-                $numVersaoMudancaAgendamento = intval(join($numVersaoMudancaAgendamento));
-                if($numVersaoMudancaAgendamento >= $numVersaoAtualSEI){
-                    $infraAgemdanemtoTarefaDTO->setStrStaPeriodicidadeExecucao('N');
-                    $infraAgemdanemtoTarefaDTO->setStrPeriodicidadeComplemento('0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55');
-                } else {
-                    $infraAgemdanemtoTarefaDTO->setStrStaPeriodicidadeExecucao('D');
-                    $infraAgemdanemtoTarefaDTO->setStrPeriodicidadeComplemento('0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23');
+                $desabilitarServicoNotificacao = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'DesabilitarServicoNotificacao', false, false);
+
+                if($desabilitarServicoNotificacao){
+
+                    $this->logar("Serviço de notificação não será instalado pois 'DesabilitarServicoNotificacao = false'.");
+                    
+                }else{
+
+                    $this->logar("CRIANDO TABELA PARA NOTIFICACAO DE ATIVIDADES.");
+                    $objInfraMetaBD = new InfraMetaBD(BancoSEI::getInstance());
+                    BancoSEI::getInstance()->executarSql(
+                        'CREATE TABLE md_wssei_notificacao_ativ (
+                            id_notificacao_atividade ' . $objInfraMetaBD->tipoNumero() . '  NOT NULL ,
+                            id_atividade ' . $objInfraMetaBD->tipoNumero() . '  NOT NULL ,
+                            titulo ' . $objInfraMetaBD->tipoTextoFixo(150) . '  NOT NULL ,
+                            mensagem ' . $objInfraMetaBD->tipoTextoGrande() . '  NOT NULL ,
+                            dth_notificacao ' . $objInfraMetaBD->tipoDataHora() . '  NOT NULL)'
+                    );
+                    BancoSEI::getInstance()->criarSequencialNativa('seq_md_wssei_notificacao_ativ',1);
+                    $objInfraMetaBD->criarIndice('md_wssei_notificacao_ativ','i01_md_wssei_notificacao_ativ',array('id_notificacao_atividade'));
+                    $objInfraMetaBD->criarIndice('md_wssei_notificacao_ativ','i02_md_wssei_notificacao_ativ',array('id_atividade'));
+                    $objInfraMetaBD->criarIndice('md_wssei_notificacao_ativ','i03_md_wssei_notificacao_ativ',array('id_notificacao_atividade','id_atividade'));
+                    BancoSEI::getInstance()->executarSql('alter table md_wssei_notificacao_ativ add constraint fk_md_wssei_not_ativ_id_ativ foreign key (id_atividade) references atividade (id_atividade) on delete cascade');
+            
+                    $infraAgemdanemtoTarefaDTO = new InfraAgendamentoTarefaDTO();
+                    $infraAgemdanemtoTarefaDTO->setStrDescricao('Agendamento para notificacao de atividades.');
+                    $infraAgemdanemtoTarefaDTO->setStrComando('MdWsSeiAgendamentoRN::notificacaoAtividades');
+            
+                    //Obtem valor do SEI.php
+                    $numVersaoAtualSEI = explode('.', SEI_VERSAO);
+                    $numVersaoAtualSEI = array_map(function($item){ return str_pad($item, 2, '0', STR_PAD_LEFT); }, $numVersaoAtualSEI);
+                    $numVersaoAtualSEI = intval(join($numVersaoAtualSEI));
+                    $numVersaoMudancaAgendamento = explode('.', '3.1.0');
+                    $numVersaoMudancaAgendamento = array_map(function($item){ return str_pad($item, 2, '0', STR_PAD_LEFT); }, $numVersaoMudancaAgendamento);
+                    $numVersaoMudancaAgendamento = intval(join($numVersaoMudancaAgendamento));
+                    if($numVersaoMudancaAgendamento >= $numVersaoAtualSEI){
+                        $infraAgemdanemtoTarefaDTO->setStrStaPeriodicidadeExecucao('N');
+                        $infraAgemdanemtoTarefaDTO->setStrPeriodicidadeComplemento('0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55');
+                    } else {
+                        $infraAgemdanemtoTarefaDTO->setStrStaPeriodicidadeExecucao('D');
+                        $infraAgemdanemtoTarefaDTO->setStrPeriodicidadeComplemento('0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23');
+                    }
+            
+                    $infraAgemdanemtoTarefaDTO->setStrSinAtivo('S');
+                    $infraAgemdanemtoTarefaDTO->setStrSinSucesso('S');
+            
+                    $infraAgemdanemtoTarefaBD = new InfraAgendamentoTarefaBD(BancoSEI::getInstance());
+                    $infraAgemdanemtoTarefaBD->cadastrar($infraAgemdanemtoTarefaDTO);
                 }
-        
-                $infraAgemdanemtoTarefaDTO->setStrSinAtivo('S');
-                $infraAgemdanemtoTarefaDTO->setStrSinSucesso('S');
-        
-                $infraAgemdanemtoTarefaBD = new InfraAgendamentoTarefaBD(BancoSEI::getInstance());
-                $infraAgemdanemtoTarefaBD->cadastrar($infraAgemdanemtoTarefaDTO);
+                
                 $this->logar("VERSÃO 0.8.12 atualizada.");
             }
         
@@ -115,16 +125,24 @@ require_once dirname(__FILE__) . '/../web/SEI.php';
         
             public function versao_1_0_4($strVersaoAtual)
             {
-                $this->logar("VERIFICANDO SE A CHAVE: TokenSecret ESTA PRESENTE NO ARQUIVO DE CONFIGURACOES.");
+
+                $desabilitarServicoNotificacao = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'DesabilitarServicoNotificacao', false, false);
+
+                if($desabilitarServicoNotificacao){
+                    $this->logar("Serviço de notificação não será instalado pois 'DesabilitarServicoNotificacao = false'.");
+                }else{
+                    $this->logar("VERIFICANDO SE A CHAVE: TokenSecret ESTA PRESENTE NO ARQUIVO DE CONFIGURACOES.");
                 
-                $token = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'TokenSecret', false);
-                if((!$token) || (strlen($token)<25)){
-                    $msg = 'Token Secret inexistente ou tamanho menor que o permitido! Verifique o manual de instalacao do módulo. ';
-                    $msg = $msg . 'O script de instalacao foi interrompido. Módulo nao instalado corretamente. ';
-                    $msg = $msg . 'Ajuste a chave e rode novamente o script.';
-                    $this->logar($msg);
-                    throw new InfraException($msg);
+                    $token = ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'TokenSecret', false);
+                    if((!$token) || (strlen($token)<25)){
+                        $msg = 'Token Secret inexistente ou tamanho menor que o permitido! Verifique o manual de instalacao do módulo. ';
+                        $msg = $msg . 'O script de instalacao foi interrompido. Módulo nao instalado corretamente. ';
+                        $msg = $msg . 'Ajuste a chave e rode novamente o script.';
+                        $this->logar($msg);
+                        throw new InfraException($msg);
+                    }
                 }
+                
         
                 $this->logar("VERSÃO 1.0.4 atualizada.");
             }

--- a/testes/PhpUnit/src/paginas/PaginaDocumento.php
+++ b/testes/PhpUnit/src/paginas/PaginaDocumento.php
@@ -71,7 +71,7 @@ class PaginaDocumento extends PaginaTeste
                 $input->value($nomeInteressado);
                 $this->test->keys(Keys::ENTER);
                 $this->test->acceptAlert();
-                sleep(2);
+                sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 2));
             }
         }
     }

--- a/testes/PhpUnit/src/paginas/PaginaEditarProcesso.php
+++ b/testes/PhpUnit/src/paginas/PaginaEditarProcesso.php
@@ -76,7 +76,7 @@ class PaginaEditarProcesso extends PaginaTeste
                 $input->value($nomeInteressado);
                 $this->test->keys(Keys::ENTER);
                 $this->test->acceptAlert();
-                sleep(2);
+                sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 2));
             }
         }
     }

--- a/testes/PhpUnit/src/paginas/PaginaIncluirDocumento.php
+++ b/testes/PhpUnit/src/paginas/PaginaIncluirDocumento.php
@@ -22,13 +22,13 @@ class PaginaIncluirDocumento extends PaginaTeste
     {
         try{
             $this->test->byId('txtFiltro')->value($tipoDocumento);
-            sleep(2);
+            sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 2));
             $this->test->byLinkText($tipoDocumento)->click();
         }
         catch (Exception $e){
             $this->test->byId("imgExibirSeries")->click();
             $this->test->byId('txtFiltro')->value($tipoDocumento);
-            sleep(2);
+            sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 2));
             $this->test->byLinkText($tipoDocumento)->click();
         }
     }
@@ -90,7 +90,7 @@ class PaginaIncluirDocumento extends PaginaTeste
 		$this->test->keys(Keys::ENTER);
 		$this->test->acceptAlert();
 
-		sleep(2);
+		sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 2));
     }
 
     public function salvarDocumento()
@@ -124,7 +124,7 @@ class PaginaIncluirDocumento extends PaginaTeste
         $this->test->frame(null);
         $this->test->frame("ifrVisualizacao");
         $this->test->byXPath("//img[@alt='Incluir Documento']")->click();
-        sleep(2);
+        sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 2));
 
         $dadosDocumento = $dadosDocumento ?: array();
         $dadosDocumento["TIPO_DOCUMENTO"] = @$dadosDocumento["TIPO_DOCUMENTO"] ?: "Ofício";
@@ -162,7 +162,7 @@ class PaginaIncluirDocumento extends PaginaTeste
         $this->test->frame(null);
         $this->test->frame("ifrVisualizacao");
         $this->test->byXPath("//img[@alt='Incluir Documento']")->click();
-        sleep(2);
+        sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 2));
 
         $dadosDocumento = $dadosDocumento ?: array();
         $dadosDocumento["TIPO_DOCUMENTO"] = @$dadosDocumento["TIPO_DOCUMENTO"] ?: "Ofício";
@@ -175,9 +175,9 @@ class PaginaIncluirDocumento extends PaginaTeste
         $dadosDocumento["HIPOTESE_LEGAL"] = @$dadosDocumento["HIPOTESE_LEGAL"] ?: "";
 
         $this->selecionarTipoDocumentoExterno();
-        sleep(2);
+        sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 2));
         $this->tipoDocumento($dadosDocumento["TIPO_DOCUMENTO"]);
-        sleep(2);        
+        sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 2));        
         
         $this->dataElaboracao($dadosDocumento["DATA_ELABORACAO"]);
         $this->formato($dadosDocumento["FORMATO_DOCUMENTO"]);

--- a/testes/PhpUnit/src/paginas/PaginaIniciarProcesso.php
+++ b/testes/PhpUnit/src/paginas/PaginaIniciarProcesso.php
@@ -18,13 +18,13 @@ class PaginaIniciarProcesso extends PaginaTeste
     {
         try{
             $this->test->byId('txtFiltro')->value($tipoProcesso);
-            sleep(2);
+            sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 2));
             $this->test->byLinkText($tipoProcesso)->click();
         }
         catch (Exception $e){
             $this->test->byId("imgExibirTiposProcedimento")->click();    
             $this->test->byId('txtFiltro')->value($tipoProcesso);
-            sleep(2);
+            sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 2));
             $this->test->byLinkText($tipoProcesso)->click();
         }
     }
@@ -96,7 +96,7 @@ class PaginaIniciarProcesso extends PaginaTeste
                 $input->value($nomeInteressado);
                 $this->test->keys(Keys::ENTER);
                 $this->test->acceptAlert();
-                sleep(2);
+                sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 2));
             }
         }
     }

--- a/testes/PhpUnit/src/paginas/PaginaProcesso.php
+++ b/testes/PhpUnit/src/paginas/PaginaProcesso.php
@@ -58,7 +58,7 @@ class PaginaProcesso extends PaginaTeste
             $this->test->frame("ifrVisualizacao");  
             $this->editarProcessoButton = $this->test->byXPath("//img[@alt='Envio Externo de Processo']");   
             $this->editarProcessoButton->click();
-            sleep(2);
+            sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 2));
             $testCase->assertContains('Envio Externo de Processo', $testCase->byCssSelector('body')->text());
             return true;
         }, 100000);
@@ -73,7 +73,7 @@ class PaginaProcesso extends PaginaTeste
 
             $this->test->frame(null);
             $this->test->frame("ifrVisualizacao");  
-            sleep(2);              
+            sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 2));              
             $testCase->assertContains('Histórico do Processo', $testCase->byCssSelector('body')->text());
             return true;
         }, 100000);
@@ -89,7 +89,7 @@ class PaginaProcesso extends PaginaTeste
             $this->test->frame("ifrVisualizacao");  
             $this->editarProcessoButton = $this->test->byXPath("//img[@alt='Consultar Recibos']");   
             $this->editarProcessoButton->click();
-            sleep(2);
+            sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 2));
             $testCase->assertContains('Consultar Recibos', $testCase->byCssSelector('body')->text());
             return true;
         }, 100000);
@@ -147,7 +147,7 @@ class PaginaProcesso extends PaginaTeste
     public function selecionarProcesso()
     {
         $this->selecionarItemArvore($this->listarArvoreProcesso()[0]);
-        sleep(1);
+        sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 1));
     }
 
     public function listarDocumentos() 

--- a/testes/PhpUnit/src/paginas/PaginaTeste.php
+++ b/testes/PhpUnit/src/paginas/PaginaTeste.php
@@ -15,7 +15,7 @@ class PaginaTeste
 
     public function alertTextAndClose($confirm = true)
     {
-        sleep(2);
+        sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 2));
         $result = $this->test->alertText();
         $result = (!is_array($result) ? $result : null);
 

--- a/versao/v2/MdWsSeiServicosV2.php
+++ b/versao/v2/MdWsSeiServicosV2.php
@@ -1742,10 +1742,10 @@ class MdWsSeiServicosV2 extends MdWsSeiVersaoServicos
                 });
             })->add(new TokenValidationMiddleware());
 
-        })
-            ->add(new ServicePermissionsMiddleware())
-            ->add(new ModuleVerificationMiddleware())
-            ->add(new EncodingMiddleware());
+        })            
+            ->add(new ModuleVerificationMiddleware())            
+            ->add(new EncodingMiddleware())
+            ->add(new ServicePermissionsMiddleware());
 
         return $this->slimApp;
     }

--- a/versao/v2/MdWsSeiServicosV2.php
+++ b/versao/v2/MdWsSeiServicosV2.php
@@ -44,7 +44,7 @@ class MdWsSeiServicosV2 extends MdWsSeiVersaoServicos
              */
             $this->post('/autenticar', function ($request, $response, $args) {
                 /** @var $response Slim\Http\Response */
-                sleep(3);
+                sleep(ConfiguracaoSEI::getInstance()->getValor('WSSEI', 'Sleep', false, 3));
                 $rn = new MdWsSeiUsuarioRN();
                 $usuarioDTO = new UsuarioDTO();
                 $usuarioDTO->setStrSigla($request->getParam('usuario'));

--- a/versao/v2/MdWsSeiServicosV2.php
+++ b/versao/v2/MdWsSeiServicosV2.php
@@ -1743,6 +1743,7 @@ class MdWsSeiServicosV2 extends MdWsSeiVersaoServicos
             })->add(new TokenValidationMiddleware());
 
         })
+            ->add(new ServicePermissionsMiddleware())
             ->add(new ModuleVerificationMiddleware())
             ->add(new EncodingMiddleware());
 


### PR DESCRIPTION
Partindo da ideia de utilizar o ws-sei como uma API estendida do SEI sem a utilização do app para smartphone. Mas pra isso ser possível, precisamos de algumas configurações para desabilitar o QrCode, Serviço de autenticação e um controle de quais serviços podem ou não ser utilizados. Portanto essas modificações visam estender as possibilidades de configuração do módulo.

Outra configuração adicionada foi o controle do sleep que existe nas requisições. Não sei o motivo de existir esta pausa nas requisições, mas adicionei uma configuração caso o usuário deseje remover este tempo de espera.

```
'DesabilitarQrCodeAplicativo' => '{(bool) se true desabilita a visão do QrCode do aplicativo no menu do SEI. Padrão=false.}',

'DesabilitarServicoNotificacao' => '{(bool) se true desabilita o serviço de autenticação. Padrão=false}',

'ServicosHabilitados' => '{(array|bool) lista de expressões regulares para habilitar apenas os serviços que combinem com os padrões listados. Padrão=false. Exemplo "ServicosHabilitados" => ["hipoteseLegal.*"]}',

'ServicosDesabilitados' => '{(array|bool) lista de expressões regulares para desabilitar apenas os serviços que combinem com os padrões listados. Padrão=false. Exemplo "ServicosDesabilitados" => ["bloco/assinatura.*","versao"]}',

'Sleep' => '{int} valor padrão para sleeps nas chamadas ',
```

